### PR TITLE
Parameterize BOARD.SpiDev()

### DIFF
--- a/SX127x/board_config.py
+++ b/SX127x/board_config.py
@@ -65,13 +65,15 @@ class BOARD:
         BOARD.spi.close()
 
     @staticmethod
-    def SpiDev():
+    def SpiDev(spi_bus=0, spi_cs=0):
         """ Init and return the SpiDev object
         :return: SpiDev object
+        :param spi_bus: The RPi SPI bus to use: 0 or 1
+        :param spi_cs: The RPi SPI chip select to use: 0 or 1
         :rtype: SpiDev
         """
         BOARD.spi = spidev.SpiDev()
-        BOARD.spi.open(0, 0)
+        BOARD.spi.open(spi_bus, spi_cs)
         return BOARD.spi
 
     @staticmethod


### PR DESCRIPTION
Hi, I'm new to github pull requests.  I thought I'd try two simple changesets that will apply cleanly to your master branch.  This is the first one; I don't know how well the second one will apply since its branch is also based on master.  Here is the commit message:

```
Parameterize BOARD.SpiDev() to allow different bus or chip select.  Defaults are 0,0.

Since the default arguments are the same as the previously hard-coded
arguments, there is no effect to end-user code.

This change allows for a radio board on a different SPI chip select,
including future use of a second radio.
```